### PR TITLE
Description not accurate, may cause confusion

### DIFF
--- a/src/main/java/fr/xebia/cascading/learn/level5/FreestyleJobs.java
+++ b/src/main/java/fr/xebia/cascading/learn/level5/FreestyleJobs.java
@@ -39,7 +39,7 @@ public class FreestyleJobs {
 	 * Now, let's try a non trivial job : td-idf. Assume that each line is a
 	 * document.
 	 * 
-	 * source field(s) : "line"
+	 * source field(s) : "id","content"
 	 * sink field(s) : "docId","tfidf","word"
 	 * 
 	 * <pre>


### PR DESCRIPTION
In the computeTfIdf() task, the inputs are different to those specified